### PR TITLE
Fix import style for InteractiveInstaller in CLI and docs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -330,7 +330,7 @@ const projectInfo = await installer.detectProjectType('./');
 Enhanced installer with interactive CLI prompts.
 
 ```javascript
-const { InteractiveInstaller } = require('@aojdevstudio/cdev');
+const InteractiveInstaller = require('@aojdevstudio/cdev');
 
 const installer = new InteractiveInstaller();
 await installer.run('./my-project');

--- a/src/cli-commands.js
+++ b/src/cli-commands.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { showHelp } = require('./cli-parser');
-const { InteractiveInstaller } = require('./interactive-installer');
+const InteractiveInstaller = require('./interactive-installer');
 
 /**
  * Execute CLI commands for parallel development workflow


### PR DESCRIPTION
## Summary
- Corrects the import statement for `InteractiveInstaller` in both CLI commands and API reference documentation
- Changes from named import to default import to match module export style

## Changes

### Documentation
- Updated `docs/api-reference.md` to import `InteractiveInstaller` as a default import instead of a named import

### Source Code
- Modified `src/cli-commands.js` to import `InteractiveInstaller` as a default import rather than a named import

## Test plan
- Verified that the CLI commands run without import errors
- Checked that the documentation example matches the actual import usage
- Ensured no runtime errors occur related to `InteractiveInstaller` import

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3de4745e-d2cb-4593-b431-ec89d9af1fc0